### PR TITLE
fix: fB64 functon doesn't error when a title is provided

### DIFF
--- a/index.html
+++ b/index.html
@@ -767,7 +767,14 @@
 
                 // Check for function calls
                 if (input.startsWith('>')) {
-                    const funcCall = input.substring(1).trim();
+                    let funcCall = input.substring(1).trim();
+                    
+                    // If there's a pipe separator, only parse the function part (before the pipe)
+                    const pipeIndex = funcCall.indexOf('|');
+                    if (pipeIndex !== -1) {
+                        funcCall = funcCall.substring(0, pipeIndex).trim();
+                    }
+                    
                     const parts = funcCall.split(' ');
                     const funcName = parts[0];
                     const args = parts.slice(1);


### PR DESCRIPTION
The `fB64` function would error if a title was provided. This is now fixed.